### PR TITLE
Allow byggeren in dev-gcp to call proxy in prod-gcp

### DIFF
--- a/.nais/prod-vars.yaml
+++ b/.nais/prod-vars.yaml
@@ -24,3 +24,9 @@ accessPolicy:
       - application: soknadsveiviser
         namespace: skjemadigitalisering
         cluster: prod-gcp
+      - application: skjemabygging-formio
+        namespace: skjemadigitalisering
+        cluster: dev-gcp
+      - application: skjemabygging-experimental
+        namespace: skjemadigitalisering
+        cluster: dev-gcp


### PR DESCRIPTION
Skjemabygging dev uses azure tenant nav.no, and therefore needs to call proxy in prod-gcp