### PR TITLE
Temporarily allow skjemautfylling-internal as inbound rule

### DIFF
--- a/.nais/prod-vars.yaml
+++ b/.nais/prod-vars.yaml
@@ -29,6 +29,9 @@ accessPolicy:
       - application: skjemautfylling
         namespace: skjemadigitalisering
         cluster: prod-gcp
+      - application: skjemautfylling-internal
+        namespace: skjemadigitalisering
+        cluster: prod-gcp
       - application: skjemabygging
         namespace: skjemadigitalisering
         cluster: prod-gcp


### PR DESCRIPTION
For testing generation of pdf with exstream in production