### PR TITLE
Fikser 'identity_provider not set' for nais/docker-build-push.

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -27,6 +27,7 @@ jobs:
         run: |
           yarn test
       - name: Build tag and push Docker image
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: nais/docker-build-push@v0
         id: docker-build-push
         with:


### PR DESCRIPTION
Dependabot har ikke tilgang til secrets.